### PR TITLE
Get the FarmShare login node from DNS

### DIFF
--- a/hosts/farmshare_ssh.sh
+++ b/hosts/farmshare_ssh.sh
@@ -6,17 +6,13 @@
 echo
 read -p "Farmshare username > "  USERNAME
 
-# Get a login node to use.
-# The current FarmShare generation uses "rice.stanford.edu", which is DNS
-# load-balanced.  "rice.stanford.edu" is currently an alias to
-# "rice.best.stanford.edu", and returns a CNAME to the best login node to use.
-# WARNING: If the load-balancing method, or the name, ever changes; this will
-# need to be updated.
-FARMSHARE_HOST=$(dig +short +recurse rice.best.stanford.edu cname)
+# The FarmShare login node is (as of 2018) rice.stanford.edu.  That is a
+# load-balanced DNS.  The use of ControlMaster will ensure that multiple
+# connections to rice.stanford.edu all go to the same host.
 
 echo "Host farmshare
     User ${USERNAME}
-    Hostname ${FARMSHARE_HOST}
+    Hostname rice.stanford.edu
     GSSAPIDelegateCredentials yes
     GSSAPIAuthentication yes
     ControlMaster auto

--- a/hosts/farmshare_ssh.sh
+++ b/hosts/farmshare_ssh.sh
@@ -14,9 +14,6 @@ read -p "Farmshare username > "  USERNAME
 # need to be updated.
 FARMSHARE_HOST=$(dig +short +recurse rice.best.stanford.edu cname)
 
-# Randomly select login node from 1..4
-LOGIN_NODE=$((1 + RANDOM % 9))
-
 echo "Host farmshare
     User ${USERNAME}
     Hostname ${FARMSHARE_HOST}

--- a/hosts/farmshare_ssh.sh
+++ b/hosts/farmshare_ssh.sh
@@ -6,12 +6,20 @@
 echo
 read -p "Farmshare username > "  USERNAME
 
+# Get a login node to use.
+# The current FarmShare generation uses "rice.stanford.edu", which is DNS
+# load-balanced.  "rice.stanford.edu" is currently an alias to
+# "rice.best.stanford.edu", and returns a CNAME to the best login node to use.
+# WARNING: If the load-balancing method, or the name, ever changes; this will
+# need to be updated.
+FARMSHARE_HOST=$(dig +short +recurse rice.best.stanford.edu cname)
+
 # Randomly select login node from 1..4
 LOGIN_NODE=$((1 + RANDOM % 9))
 
 echo "Host farmshare
     User ${USERNAME}
-    Hostname rice0${LOGIN_NODE}.stanford.edu
+    Hostname ${FARMSHARE_HOST}
     GSSAPIDelegateCredentials yes
     GSSAPIAuthentication yes
     ControlMaster auto


### PR DESCRIPTION
FarmShare login node hostnames are handed out using load-balanced DNS.
Use that mechanism to identify the FarmShare login node to use.

NOTE: Requires the `dig` command.  Hopefully this is a safe assumption!